### PR TITLE
Handle missing winreg module

### DIFF
--- a/utils/config_manager.py
+++ b/utils/config_manager.py
@@ -5,19 +5,22 @@
 
 import os
 import json
-import winreg
+try:
+    import winreg  # type: ignore
+except ImportError:  # pragma: no cover
+    winreg = None  # type: ignore
 
 
 class ConfigManager:
     """配置管理器"""
-    
+
     def __init__(self):
         self.config_path = self.get_config_path()
-    
+
     def get_config_path(self):
         """获取配置文件路径"""
         return os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "config.json")
-    
+
     def load_config(self):
         """加载配置文件"""
         if os.path.exists(self.config_path):
@@ -27,7 +30,7 @@ class ConfigManager:
             except Exception as e:
                 print(f"加载配置文件失败: {e}")
         return {"save_path": os.path.dirname(os.path.abspath(__file__))}
-    
+
     def save_config(self, config_data):
         """保存配置文件"""
         try:
@@ -35,24 +38,29 @@ class ConfigManager:
                 json.dump(config_data, f, ensure_ascii=False, indent=4)
         except Exception as e:
             print(f"保存配置文件失败: {e}")
-    
+
     def get_steam_install_path(self):
         """通过注册表获取Steam安装路径"""
-        try:
-            # 打开Steam的注册表项
-            with winreg.OpenKey(winreg.HKEY_LOCAL_MACHINE, r"SOFTWARE\WOW6432Node\Valve\Steam") as key:
-                # 读取InstallPath值
-                install_path = winreg.QueryValueEx(key, "InstallPath")[0]
-                return install_path
-        except WindowsError:
-            # 如果在注册表中找不到，尝试从默认路径查找
-            default_paths = [
-                r"C:\Program Files (x86)\Steam",
-                r"C:\Program Files\Steam",
-                r"D:\Program Files (x86)\Steam",
-                r"D:\Program Files\Steam"
-            ]
-            for path in default_paths:
-                if os.path.exists(os.path.join(path, "steam.exe")):
-                    return path
-            return None
+        if winreg:
+            try:
+                # 打开Steam的注册表项
+                with winreg.OpenKey(winreg.HKEY_LOCAL_MACHINE, r"SOFTWARE\\WOW6432Node\\Valve\\Steam") as key:
+                    # 读取InstallPath值
+                    install_path = winreg.QueryValueEx(key, "InstallPath")[0]
+                    return install_path
+            except OSError:
+                # 注册表未找到或无法访问，继续尝试默认路径
+                pass
+
+        # 如果在注册表中找不到，尝试从默认路径查找
+        default_paths = [
+            r"C:\\Program Files (x86)\\Steam",
+            r"C:\\Program Files\\Steam",
+            r"D:\\Program Files (x86)\\Steam",
+            r"D:\\Program Files\\Steam"
+        ]
+        for path in default_paths:
+            if os.path.exists(os.path.join(path, "steam.exe")):
+                return path
+        return None
+


### PR DESCRIPTION
## Summary
- Avoid importing `winreg` on non-Windows systems so config loading works cross-platform
- Fallback to default Steam paths when registry access fails

## Testing
- `python -c "from utils.config_manager import ConfigManager"`
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6895f5d7142c83269c64f2a5ddf762bc